### PR TITLE
Add anyformat-workflow skill

### DIFF
--- a/config/claude/skills/anyformat-workflow/SKILL.md
+++ b/config/claude/skills/anyformat-workflow/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: anyformat-workflow
+description: "Create an anyformat workflow (graph + extraction schema) against the local backend, upload a PDF, and fetch results. Covers all 10 node types. Use when the user asks to build/create/spin up a workflow, upload a schema, or run a document through the local backend."
+triggers:
+  - create workflow
+  - new workflow
+  - upload schema
+  - upload pdf
+  - run workflow locally
+---
+
+# anyformat-workflow
+
+End-to-end recipe for creating a workflow, attaching an extraction schema, uploading a PDF, and fetching results against the **local** anyformat backend.
+
+## Decision guide — read this first
+
+| Case | Endpoints |
+|---|---|
+| **Single extract** (linear `parse → extract`, or any graph with one extract node) | `POST /api/v2/saas_manager/workflows/` — graph + nodes + flat `fields[]` in one call (defaults to `extract_1`) |
+| **Multiple extracts** (splitter/classify routing to >1 extract) | `POST …/workflows/` with graph + nodes **only**, then `PUT /api/v2/saas_manager/workflow-versions/{version_id}/config/` with `nodes` as a **dict keyed by node_id**, `fields` nested under each |
+| **Edit schema on existing workflow** | `PUT …/workflow-versions/{id}/config/` — creates a **new version**, does not mutate in place |
+
+Why: the one-shot POST takes a flat `fields[]` that binds all fields to `extract_1` (or a single `graph_node_id`). Per-node schemas need the atomic config PUT. Learned empirically — don't try to cram a splitter workflow into one POST.
+
+## The 4-step flow
+
+1. **Auth** — mint an API key (or reuse one). See [`reference/auth.md`](reference/auth.md).
+2. **Create workflow (+ schema)** — POST `/api/v2/saas_manager/workflows/`, optionally followed by PUT config. See [`reference/api.md`](reference/api.md#create) and [`reference/schemas.md`](reference/schemas.md).
+3. **Upload PDF** — POST `/api/v2/files/upload/` (base64). See [`reference/api.md`](reference/api.md#upload).
+4. **Run & fetch** — POST `/api/v2/demo/run_extraction_demo/`, poll `/api/v3/file-collections/{id}/extraction-status/`, then GET `…/results/`. See [`reference/api.md`](reference/api.md#run).
+
+## Quick reference
+
+- **All 10 node types** (config shapes, routing rules, DOT syntax) → [`reference/nodes.md`](reference/nodes.md)
+- **Endpoints** (request/response shapes, auth, versioning) → [`reference/api.md`](reference/api.md)
+- **Auth setup** (mint API key, X-Current-Org) → [`reference/auth.md`](reference/auth.md)
+- **Schema shape** (field types, nesting, enums, per-node scoping) → [`reference/schemas.md`](reference/schemas.md)
+- **Working payloads** (linear, splitter, classify, smart_lookup) → [`reference/examples.md`](reference/examples.md)
+- **Fake PDF generator** for the splitter schemas (faker + reportlab via PEP 723) → [`reference/fixtures/make_fixtures.py`](reference/fixtures/make_fixtures.py) — see [`reference/examples.md#fixtures`](reference/examples.md#fixtures)
+- **3-way mixed PDF** (invoice + package label + boarding pass, one page each) for splitter end-to-end runs with real data in every branch → [`scripts/make_mixed.py`](scripts/make_mixed.py)
+
+## Quickstart — linear parse → extract (one POST)
+
+```bash
+export BASE=http://localhost:8080
+export TOKEN=...   # reference/auth.md
+export ORG_ID=...
+
+curl -sS "$BASE/api/v2/saas_manager/workflows/" \
+  -H "Authorization: Bearer $TOKEN" -H "X-Current-Org: $ORG_ID" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Invoice extractor",
+    "graph": "digraph G { \"parse_1\" [class=\"parse\"]; \"extract_1\" [class=\"extract\"]; \"parse_1\" -> \"extract_1\"; }",
+    "nodes": [
+      {"node_id":"parse_1","type":"parse","config":{"engine":"Fast"}},
+      {"node_id":"extract_1","type":"extract","config":{"engine":"Fast","use_images":false}}
+    ],
+    "fields": [
+      {"name":"invoice_number","description":"Invoice ID","data_type":"string","display_order":10000},
+      {"name":"total_amount","description":"Grand total","data_type":"float","display_order":20000}
+    ]
+  }'
+```
+
+For multi-extract (splitter/classify), see [`reference/examples.md#splitter`](reference/examples.md#splitter).
+
+## Gotcha — `engine` is mandatory on parse / extract / master_file
+
+Every `parse`, `extract`, and `master_file` node config MUST include `"engine": "Fast"` or `"engine": "Performant"`. The backend's `execution_builder.py:243` silently drops these node types from `task_settings` when `engine` is missing. Core then crashes at runtime with `RuntimeError: No config provided for task: <node_id>` inside `_synthesize_lookup_nodes` — a misleading stack trace that points at the synthesis pass, not the real cause.
+
+Always include `engine` alongside `use_images`, `lookup_enabled`, or any other extract config:
+```json
+{"node_id":"extract_1","type":"extract","config":{"engine":"Fast","use_images":false}}
+```
+
+## Full end-to-end bash
+
+See [`reference/examples.md#end-to-end`](reference/examples.md#end-to-end) — pasteable script covering create → upload PDF → run → poll → fetch results.
+
+## Verified against
+
+- Local backend at commit on `feat/splits-identity-rebuild` (2026-04-21) — this skill was dog-fooded on a splitter workflow with two extract branches and the PUT config flow worked end-to-end.
+- Source anchors and drift check: [`reference/api.md#source-anchors`](reference/api.md#source-anchors)

--- a/config/claude/skills/anyformat-workflow/reference/api.md
+++ b/config/claude/skills/anyformat-workflow/reference/api.md
@@ -1,0 +1,227 @@
+# API reference
+
+Base URL for local dev: `http://localhost:8080`. All requests require:
+
+- `Authorization: Bearer $TOKEN`
+- `X-Current-Org: $ORG_ID` (strictly required on `/api/v3/`; recommended on `/api/v2/`)
+
+## Versioning invariant — read this
+
+Every `PUT /api/v2/saas_manager/workflow-versions/{id}/config/` call **creates a new WorkflowVersion row**, it does NOT mutate in place. The POST `…/workflows/` returns `versions[0].id = N`; your first PUT bumps it to `N+1`. Use the latest `version_id` for subsequent operations (extraction runs, fields GET, results fetch).
+
+---
+
+## 1) Create workflow
+
+<a id="create"></a>
+
+`POST /api/v2/saas_manager/workflows/`
+
+Creates a Workflow + initial WorkflowVersion + graph nodes + (optionally) extraction fields in one atomic call. Use when: all fields belong to **one** extract node (or you'll attach schemas via a follow-up PUT config).
+
+### Request
+
+```json
+{
+  "name": "...",
+  "description": "...",
+  "graph": "digraph G { ... }",
+  "nodes": [
+    { "node_id": "...", "type": "...", "config": { ... }, "position": {"x":0,"y":0} }
+  ],
+  "fields": [
+    { "name": "...", "description": "...", "data_type": "...", "source": "extraction", "display_order": 10000 }
+  ],
+  "manual_fields": []
+}
+```
+
+### Rules
+
+- `graph` and `nodes` must be **both present or both absent** — if absent, default `parse_1 → extract_1` is created.
+- `fields[]` without per-field `graph_node_id` → all fields bound to `extract_1` by name. For multi-extract, use the config PUT instead (below).
+- `data_type` ∈ `string|date|datetime|float|integer|boolean|enum|multi_select|object`.
+
+### Response (201)
+
+```json
+{
+  "id": "<workflow_uuid>",
+  "name": "...",
+  "versions": [{ "id": 123, "name": "...", "created_at": "..." }]
+}
+```
+
+Capture `id` (workflow UUID) and `versions[0].id` (numeric version_id).
+
+---
+
+## 2) Atomic config (multi-extract path, schema edits)
+
+<a id="config"></a>
+
+`GET /api/v2/saas_manager/workflow-versions/{version_id}/config/` — read current config.
+`PUT /api/v2/saas_manager/workflow-versions/{version_id}/config/` — save full config, creating a new version.
+
+### Key difference from POST workflows/
+
+`nodes` is a **dict keyed by node_id**, and `fields` are **nested under each node** (not flat top-level).
+
+### PUT request
+
+```json
+{
+  "version_id": 4,
+  "graph": "digraph G { ... }",
+  "nodes": {
+    "parse_1":    { "type": "parse",             "config": {...}, "position": {...}, "fields": [] },
+    "splitter_1": { "type": "document_splitter", "config": {...}, "position": {...}, "fields": [] },
+    "extract_1":  { "type": "extract",           "config": {...}, "position": {...}, "fields": [ { ... }, { ... } ] },
+    "extract_2":  { "type": "extract",           "config": {...}, "position": {...}, "fields": [ { ... }, { ... } ] }
+  },
+  "manual_fields": []
+}
+```
+
+### Response (200)
+
+```json
+{ "version_id": 5 }
+```
+
+The returned `version_id` is the **new** version. Use it for subsequent extraction runs.
+
+### Common errors
+
+- `400` with `"graph and nodes must be provided together"` — you sent one without the other.
+- `400` field-bearing-on-non-field-node — only `extract`, `smart_table`, `smart_lookup`, `master_file` can have `fields`.
+- `409` version conflict — the `version_id` in the body doesn't match the current latest (optimistic concurrency).
+
+---
+
+## 3) Upload a PDF
+
+<a id="upload"></a>
+
+`POST /api/v2/files/upload/`
+
+JSON body, base64-encoded file content.
+
+### Request
+
+```json
+{
+  "content": "<base64>",
+  "filename": "invoice.pdf",
+  "format": "pdf",
+  "extraction_name": "invoice-2026-04",
+  "workflow_id": "<workflow_uuid>",
+  "file_collection_id": null,
+  "manual_field_values": {}
+}
+```
+
+### Response (201)
+
+```json
+{
+  "file_id": 789,
+  "file_uri": "s3://...",
+  "file_collection_id": "<collection_uuid>",
+  "filename": "invoice.pdf"
+}
+```
+
+Capture `file_collection_id` — it's the anchor for runs and result fetches.
+
+### Generating a test PDF
+
+```python
+from reportlab.pdfgen import canvas
+c = canvas.Canvas("invoice.pdf")
+c.drawString(100, 800, "INVOICE #INV-2026-001")
+c.drawString(100, 780, "Date: 2026-04-21")
+c.drawString(100, 760, "Total: $1,234.56")
+c.save()
+```
+
+---
+
+## 4) Run the extraction
+
+<a id="run"></a>
+
+`POST /api/v2/demo/run_extraction_demo/` — enqueues the workflow run (async).
+
+### Request
+
+```json
+{ "version_id": 5, "file_collection_id": "<collection_uuid>" }
+```
+
+### Response (200)
+
+```json
+{ "status": "success", "extraction_id": 456, ... }
+```
+
+---
+
+## 5) Poll status
+
+`GET /api/v3/file-collections/{collection_id}/extraction-status/`
+
+### Response
+
+```json
+{ "status": "pending|queued|in_progress|processed|failed|cancelled", "processed_at": "...", "workflow_version_id": 5 }
+```
+
+---
+
+## 6) Fetch results
+
+`GET /api/v3/file-collections/{collection_id}/results/?workflow_version_id={id}`
+
+### Response
+
+```json
+{
+  "collection_id": "...",
+  "verification_url": "https://...",
+  "results": [
+    { "field_name": "invoice_number", "value": "INV-001", "confidence": 0.95, "evidence": [...] }
+  ]
+}
+```
+
+---
+
+## 7) Other useful endpoints
+
+- `GET /api/v2/saas_manager/workflows/` — list workflows. Add `?include=versions,fields,file_count,file_status_count,extraction_count`.
+- `GET /api/v2/saas_manager/workflows/{id}/` — fetch one workflow.
+- `GET /api/v2/saas_manager/workflows/{id}/graph/?version_id={v}` — render-friendly view with DOT + per-node config + positions.
+- `GET /api/v2/saas_manager/workflow-versions/{id}/fields/` — list fields (read-only; writes go through PUT config).
+- `POST /api/v2/saas_manager/workflows/{id}/duplicate/` — clone a workflow.
+- `DELETE /api/v2/saas_manager/workflows/{id}/` — soft delete.
+
+---
+
+## Source anchors
+
+<a id="source-anchors"></a>
+
+If endpoint shapes drift, verify against these files:
+
+| Endpoint | File:line |
+|---|---|
+| `POST /workflows/` | `anyformat/services/backend/src/anyformat/backend/apps/saas_manager/views/workflow_views.py:378` |
+| Serializer for POST body | `…/apps/workflow_manager/serializers.py:372` (`WorkflowFromJsonSerializer`) |
+| `PUT/GET /workflow-versions/{id}/config/` | `…/apps/saas_manager/views/workflow_version_views.py:450` |
+| Fields shape | `…/apps/saas_manager/serializers/field_serializer.py:198` (`FieldCreationSerializer`) |
+| Bulk field validator | `…/apps/saas_manager/serializers/field_bulk_serializer.py:15` |
+| `POST /files/upload/` | `…/apps/workflow_manager/serializers.py:22` (`UploadFileSerializer`) |
+| `POST /demo/run_extraction_demo/` | `…/apps/extraction_manager/views.py:26` |
+| v3 status/results | `…/apps/v3/files.py:586` (status), `:617` (results) |
+| Auth middleware | `…/utils/auth/rest_authenticators.py:164` (`Auth0JWTMachineAuthentication`) |

--- a/config/claude/skills/anyformat-workflow/reference/auth.md
+++ b/config/claude/skills/anyformat-workflow/reference/auth.md
@@ -1,0 +1,79 @@
+# Auth — local dev
+
+Local backend requires a bearer token. Two options:
+
+1. **Auth0 JWT** — obtained via the frontend OIDC flow. Fine for UI sessions, tedious for CLI.
+2. **API key** — the practical path. Mint one via a management script against the running stack.
+
+## Check what already exists
+
+```bash
+docker compose exec -T -w /app/anyformat/services/backend/src/anyformat/backend backend \
+  python manage.py shell -c "
+from anyformat.backend.apps.saas_manager.models import APIKey, Organization
+from django.contrib.auth import get_user_model
+U = get_user_model()
+print('users:',     U.objects.count())
+print('orgs:',      Organization.objects.count())
+print('keys:',      APIKey.objects.count())
+print('orgs dump:', list(Organization.objects.values('id','name')[:5]))
+print('users dump:', list(U.objects.values('id','username','email')[:5]))
+"
+```
+
+A fresh local docker-compose seeds **one user** (`username=anyformat`, `email=anyformat@localhost`) and **one org**. The seeded user has an API key in the DB, but **the raw key is not recoverable** — only its SHA256 hash is stored. You have to mint a new one.
+
+## Mint a fresh API key
+
+```bash
+docker compose exec -T -w /app/anyformat/services/backend/src/anyformat/backend backend \
+  python manage.py shell -c "
+import secrets
+from anyformat.backend.iam.domain.entities import APIKey as APIKeyEntity
+from anyformat.backend.apps.saas_manager.models import APIKey, Organization
+from django.contrib.auth import get_user_model
+U = get_user_model()
+user = U.objects.get(username='anyformat')
+org  = Organization.objects.first()
+raw  = 'sk-dev-' + secrets.token_urlsafe(32)
+APIKey.objects.create(
+    owner=user, organization=org,
+    key_hash=APIKeyEntity.hash_key(raw),
+    prefix=APIKeyEntity._mask(raw),
+    name='claude-dev',
+)
+print('KEY='    + raw)
+print('ORG_ID=' + str(org.id))
+"
+```
+
+Copy the two lines into your shell:
+
+```bash
+export TOKEN=sk-dev-...
+export ORG_ID=...
+export BASE=http://localhost:8080
+```
+
+## Verify
+
+```bash
+curl -sS -o /dev/null -w "HTTP %{http_code}\n" "$BASE/api/v2/saas_manager/workflows/" \
+  -H "Authorization: Bearer $TOKEN" -H "X-Current-Org: $ORG_ID"
+# HTTP 200 = good
+# HTTP 401 = wrong key / wrong hash
+# HTTP 403 = org missing or permissions check failed
+```
+
+## How it works (for when things break)
+
+- Authenticator: `Auth0JWTMachineAuthentication` — backend hashes the bearer with SHA256, matches against `APIKey.key_hash` (see `anyformat/services/backend/src/anyformat/backend/utils/auth/rest_authenticators.py:164`).
+- On match, `request.META["HTTP_X_CURRENT_ORG"]` is set automatically from the key's `organization_id` — so for v2 endpoints you can often omit `X-Current-Org`. **v3 endpoints still expect it**; always send it.
+- Disabled keys: set `is_active=False` on the `APIKey` row.
+- Hashing helper: `APIKeyEntity.hash_key(raw) -> sha256 hex`; `APIKeyEntity._mask(raw)` → short prefix for display.
+
+## Gotchas
+
+- The `anyformat` seeded user exists after `docker compose up` — no manual seeding needed.
+- APIKey prefix ≠ actual key; it's just a display fingerprint. Always use the raw `sk-dev-...` value as the bearer.
+- The ORG_ID is **UUIDv7 hyphenated form** (e.g., `069e7d83-478d-72c6-8000-f2cf7d3dd2bc`). Hex form also works in most places.

--- a/config/claude/skills/anyformat-workflow/reference/examples.md
+++ b/config/claude/skills/anyformat-workflow/reference/examples.md
@@ -1,0 +1,264 @@
+# Working examples
+
+All examples assume:
+
+```bash
+export BASE=http://localhost:8080
+export TOKEN=sk-dev-...     # reference/auth.md
+export ORG_ID=...
+```
+
+## 1) Linear parse → extract (one-shot POST)
+
+<a id="linear"></a>
+
+Simplest case. One call, everything embedded.
+
+```bash
+curl -sS "$BASE/api/v2/saas_manager/workflows/" \
+  -H "Authorization: Bearer $TOKEN" -H "X-Current-Org: $ORG_ID" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Invoice extractor",
+    "graph": "digraph G { \"parse_1\" [class=\"parse\"]; \"extract_1\" [class=\"extract\"]; \"parse_1\" -> \"extract_1\"; }",
+    "nodes": [
+      {"node_id":"parse_1","type":"parse","config":{"engine":"Fast"}},
+      {"node_id":"extract_1","type":"extract","config":{"engine":"Fast","use_images":false}}
+    ],
+    "fields": [
+      {"name":"invoice_number","description":"Invoice ID","data_type":"string","display_order":10000},
+      {"name":"total_amount","description":"Grand total","data_type":"float","display_order":20000}
+    ]
+  }'
+```
+
+---
+
+## 2) Splitter → two extract branches
+
+<a id="splitter"></a>
+
+This is the pattern to use whenever you have more than one extract node. **Two calls**: POST creates workflow + graph, PUT attaches per-node schemas.
+
+### Step A — create workflow (graph + nodes only)
+
+```bash
+CREATE_BODY=$(cat <<'EOF'
+{
+  "name": "Invoices + Emails splitter",
+  "description": "Parse -> split -> extract (invoices | emails)",
+  "graph": "digraph G { \"parse_1\" [class=\"parse\"]; \"splitter_1\" [class=\"document_splitter\"]; \"extract_1\" [class=\"extract\"]; \"extract_2\" [class=\"extract\"]; \"parse_1\" -> \"splitter_1\"; \"splitter_1\":\"invoices\" -> \"extract_1\"; \"splitter_1\":\"emails\" -> \"extract_2\"; }",
+  "nodes": [
+    {"node_id":"parse_1",   "type":"parse",             "config":{"engine":"Fast","visual_grounding_enabled":true}, "position":{"x":200,"y":300}},
+    {"node_id":"splitter_1","type":"document_splitter", "config":{"rules":[
+      {"id":"r-inv","name":"invoices","description":"Invoice documents: has invoice number, line items, total, vendor."},
+      {"id":"r-eml","name":"emails",  "description":"Email correspondence: has from/to, subject, date, body."}
+    ]}, "position":{"x":450,"y":300}},
+    {"node_id":"extract_1", "type":"extract", "config":{"engine":"Fast","use_images":false}, "position":{"x":750,"y":180}},
+    {"node_id":"extract_2", "type":"extract", "config":{"engine":"Fast","use_images":false}, "position":{"x":750,"y":420}}
+  ]
+}
+EOF
+)
+
+CREATE=$(curl -sS "$BASE/api/v2/saas_manager/workflows/" \
+  -H "Authorization: Bearer $TOKEN" -H "X-Current-Org: $ORG_ID" \
+  -H "Content-Type: application/json" -d "$CREATE_BODY")
+
+WORKFLOW_ID=$(echo "$CREATE" | jq -r .id)
+VERSION_ID=$( echo "$CREATE" | jq -r .versions[0].id)
+echo "workflow=$WORKFLOW_ID initial_version=$VERSION_ID"
+```
+
+### Step B — PUT config with per-node schemas
+
+```bash
+PUT_BODY=$(jq -n --argjson v "$VERSION_ID" '{
+  version_id: $v,
+  graph: "digraph G { \"parse_1\" [class=\"parse\"]; \"splitter_1\" [class=\"document_splitter\"]; \"extract_1\" [class=\"extract\"]; \"extract_2\" [class=\"extract\"]; \"parse_1\" -> \"splitter_1\"; \"splitter_1\":\"invoices\" -> \"extract_1\"; \"splitter_1\":\"emails\" -> \"extract_2\"; }",
+  nodes: {
+    parse_1:    {type:"parse",             config:{engine:"Fast",visual_grounding_enabled:true}, position:{x:200,y:300}, fields:[]},
+    splitter_1: {type:"document_splitter", config:{rules:[
+      {id:"r-inv",name:"invoices",description:"Invoice documents: has invoice number, line items, total, vendor."},
+      {id:"r-eml",name:"emails",  description:"Email correspondence: has from/to, subject, date, body."}
+    ]}, position:{x:450,y:300}, fields:[]},
+    extract_1: {type:"extract", config:{engine:"Fast",use_images:false}, position:{x:750,y:180}, fields:[
+      {name:"invoice_number",description:"Invoice ID / reference number as printed on the document",data_type:"string", source:"extraction",is_list:false,display_order:10000},
+      {name:"issue_date",    description:"Date the invoice was issued",                              data_type:"date",   source:"extraction",is_list:false,display_order:20000},
+      {name:"due_date",      description:"Payment due date",                                         data_type:"date",   source:"extraction",is_list:false,display_order:30000},
+      {name:"vendor_name",   description:"Name of the issuing vendor / supplier",                    data_type:"string", source:"extraction",is_list:false,display_order:40000},
+      {name:"total_amount",  description:"Grand total including taxes",                              data_type:"float",  source:"extraction",is_list:false,display_order:50000},
+      {name:"currency",      description:"ISO 4217 currency code (USD, EUR, ...)",                   data_type:"string", source:"extraction",is_list:false,display_order:60000}
+    ]},
+    extract_2: {type:"extract", config:{engine:"Fast",use_images:false}, position:{x:750,y:420}, fields:[
+      {name:"sender",         description:"Email address in the From: header",       data_type:"string",  source:"extraction",is_list:false,display_order:10000},
+      {name:"recipients",     description:"All To: / Cc: recipient email addresses", data_type:"string",  source:"extraction",is_list:true, display_order:20000},
+      {name:"subject",        description:"Email subject line",                      data_type:"string",  source:"extraction",is_list:false,display_order:30000},
+      {name:"sent_at",        description:"Datetime the email was sent",             data_type:"datetime",source:"extraction",is_list:false,display_order:40000},
+      {name:"body_summary",   description:"One-sentence summary of the email body",  data_type:"string",  source:"extraction",is_list:false,display_order:50000},
+      {name:"has_attachments",description:"Whether the email mentions attachments",  data_type:"boolean", source:"extraction",is_list:false,display_order:60000}
+    ]}
+  },
+  manual_fields: []
+}')
+
+PUT=$(curl -sS -X PUT "$BASE/api/v2/saas_manager/workflow-versions/$VERSION_ID/config/" \
+  -H "Authorization: Bearer $TOKEN" -H "X-Current-Org: $ORG_ID" \
+  -H "Content-Type: application/json" -d "$PUT_BODY")
+
+NEW_VERSION_ID=$(echo "$PUT" | jq -r .version_id)
+echo "active_version=$NEW_VERSION_ID"
+```
+
+The PUT returns a **new** version_id. Use `NEW_VERSION_ID` for extraction runs, not `VERSION_ID`.
+
+---
+
+## 3) Classify → routed extract
+
+Same shape as splitter — classify is the LLM-classifier variant. Port labels on edges must match `categories[].name`.
+
+```
+digraph G {
+  "parse_1"    [class="parse"];
+  "classify_1" [class="classify"];
+  "extract_a"  [class="extract"];
+  "extract_b"  [class="extract"];
+
+  "parse_1" -> "classify_1";
+  "classify_1":"invoice" -> "extract_a";
+  "classify_1":"receipt" -> "extract_b";
+}
+```
+
+`classify_1` config:
+
+```json
+{
+  "user_prompt": "Classify this document as either an invoice or a receipt.",
+  "categories": [
+    { "id": "c-inv", "name": "invoice", "description": "Has invoice number, line items, total." },
+    { "id": "c-rec", "name": "receipt", "description": "Store receipt, typically shorter." }
+  ]
+}
+```
+
+---
+
+## 4) Extract with smart_lookup enrichment
+
+Instead of declaring a separate `smart_lookup` node, set `lookup_enabled: true` on the extract. The core synthesizes the successor at runtime.
+
+```json
+{
+  "node_id": "extract_1",
+  "type": "extract",
+  "config": {
+    "engine": "Fast",
+    "use_images": false,
+    "lookup_enabled": true,
+    "lookup_files": ["s3://bucket/vendor_catalog.csv"],
+    "lookup_schema": [
+      { "name": "vendor_id", "description": "Vendor ID from catalog", "data_type": "string" }
+    ],
+    "lookup_suggestion": "Match the extracted vendor_name against the catalog's 'company_name' column."
+  }
+}
+```
+
+---
+
+## Generating fake test PDFs
+
+<a id="fixtures"></a>
+
+For schema-driven test data, use `fixtures/make_fixtures.py`. It's a self-contained [PEP 723](https://peps.python.org/pep-0723/) script — dependencies declared inline, no venv setup. Generates two PDFs aligned with the splitter workflow's schemas:
+
+- **`invoice.pdf`** — contains `invoice_number`, `issue_date`, `due_date`, `vendor_name`, `total_amount`, `currency`. Routes to `extract_1` via the splitter's `invoices` port.
+- **`email.pdf`** — contains `sender`, `recipients`, `subject`, `sent_at`, `body_summary`, `has_attachments`. Routes to `extract_2` via the `emails` port.
+
+### Run
+
+```bash
+uv run /Users/andrew/.claude/skills/anyformat-workflow/reference/fixtures/make_fixtures.py
+# → /tmp/anyformat-demo/invoice.pdf
+# → /tmp/anyformat-demo/email.pdf
+
+# or write somewhere else:
+uv run .../make_fixtures.py /path/to/out_dir
+```
+
+### Output (truth shipped to stdout)
+
+Each run prints the ground-truth values that were baked into the PDF, so you can sanity-check extraction fidelity:
+
+```
+[invoice] invoice.pdf: {'invoice_number': 'INV-2019-7067', 'issue_date': '2026-01-22', 'due_date': '2026-02-05', 'vendor_name': 'Casey Group', 'total_amount': 4202.57, 'currency': 'GBP'}
+[email]   email.pdf:   {'sender': 'johnsontyler@anderson.com', 'recipients': [...], 'subject': '...', 'sent_at': '...', 'has_attachments': False}
+```
+
+### Why reportlab, not pdfplumber
+
+`pdfplumber` **reads** PDFs; for **generation** you need `reportlab` (or `fpdf2`). The script uses `reportlab` + `faker`, declared inline via PEP 723:
+
+```python
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["reportlab", "faker"]
+# ///
+```
+
+`uv run` reads those headers, builds an ephemeral venv, and runs the script — first invocation pulls deps (~2s), subsequent runs are instant.
+
+### Extending the script
+
+- Match a new schema: add a `make_<kind>()` function that draws the expected fields onto a canvas, return a `{field_name: truth_value}` dict so the printed truth matches your schema.
+- Skew the distribution: biased coin flips on `has_attachments`, `currency`, line-item count, etc., are already in the script — tweak in place.
+- Deterministic fixtures: add `Faker.seed_instance(42)` and `random.seed(42)` at the top for reproducible fixtures across runs.
+
+---
+
+## End-to-end (generate → upload → run → poll → fetch)
+
+<a id="end-to-end"></a>
+
+Assumes you've already run Example 1 or 2 and have `WORKFLOW_ID` + `NEW_VERSION_ID` in scope.
+
+```bash
+# 0. Generate a fake PDF matching the schema
+uv run /Users/andrew/.claude/skills/anyformat-workflow/reference/fixtures/make_fixtures.py
+PDF=/tmp/anyformat-demo/invoice.pdf   # or email.pdf
+
+# Upload PDF
+PDF_B64=$(base64 -i "$PDF" | tr -d '\n')
+UPLOAD=$(curl -sS "$BASE/api/v2/files/upload/" \
+  -H "Authorization: Bearer $TOKEN" -H "X-Current-Org: $ORG_ID" \
+  -H "Content-Type: application/json" \
+  -d "{\"content\":\"$PDF_B64\",\"filename\":\"$(basename $PDF)\",\"format\":\"pdf\",\"extraction_name\":\"demo\",\"workflow_id\":\"$WORKFLOW_ID\"}")
+COLLECTION_ID=$(echo "$UPLOAD" | jq -r .file_collection_id)
+
+# Run
+curl -sS "$BASE/api/v2/demo/run_extraction_demo/" \
+  -H "Authorization: Bearer $TOKEN" -H "X-Current-Org: $ORG_ID" \
+  -H "Content-Type: application/json" \
+  -d "{\"version_id\":$NEW_VERSION_ID,\"file_collection_id\":\"$COLLECTION_ID\"}"
+
+# Poll
+until [ "$(curl -sS "$BASE/api/v3/file-collections/$COLLECTION_ID/extraction-status/" \
+           -H "Authorization: Bearer $TOKEN" -H "X-Current-Org: $ORG_ID" | jq -r .status)" = "processed" ]; do
+  sleep 3
+done
+
+# Fetch
+curl -sS "$BASE/api/v3/file-collections/$COLLECTION_ID/results/?workflow_version_id=$NEW_VERSION_ID" \
+  -H "Authorization: Bearer $TOKEN" -H "X-Current-Org: $ORG_ID" | jq .
+```
+
+## Known-good reference run
+
+The splitter example above (Example 2) was executed successfully against local backend on 2026-04-21:
+
+- Workflow `069e7d8f-cd78-7da2-8000-e808599213c3`
+- `extract_1` got 6 invoice fields; `extract_2` got 6 email fields (including `recipients` with `is_list: true`)
+- POST returned version 4; PUT-config returned version 5
+- Verified via GET `…/config/` round-trip that all nodes, configs, and per-node fields persisted correctly

--- a/config/claude/skills/anyformat-workflow/reference/fixtures/make_fixtures.py
+++ b/config/claude/skills/anyformat-workflow/reference/fixtures/make_fixtures.py
@@ -1,0 +1,144 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["reportlab", "faker"]
+# ///
+"""Generate fake invoice + email PDFs shaped to the anyformat splitter workflow schemas.
+
+Run: uv run /tmp/anyformat-demo/script.py [out_dir]
+
+Produces:
+  - invoice.pdf  — hits the `invoices` branch (extract_1)
+  - email.pdf    — hits the `emails`   branch (extract_2)
+"""
+
+import random
+import sys
+from datetime import timedelta
+from pathlib import Path
+
+from faker import Faker
+from reportlab.lib.pagesizes import letter
+from reportlab.lib.units import inch
+from reportlab.pdfgen import canvas
+
+fake = Faker()
+OUT = Path(sys.argv[1] if len(sys.argv) > 1 else "/tmp/anyformat-demo")
+OUT.mkdir(parents=True, exist_ok=True)
+
+
+def make_invoice(path: Path) -> dict:
+    c = canvas.Canvas(str(path), pagesize=letter)
+    W, H = letter
+
+    issue = fake.date_between(start_date="-90d", end_date="today")
+    due = issue + timedelta(days=random.choice([14, 30, 45, 60]))
+    currency = random.choice(["USD", "EUR", "GBP"])
+    symbol = {"USD": "$", "EUR": "€", "GBP": "£"}[currency]
+    vendor = fake.company()
+    number = f"INV-{fake.year()}-{random.randint(1000, 9999)}"
+
+    c.setFont("Helvetica-Bold", 22); c.drawString(inch, H - inch, "INVOICE")
+
+    y = H - 1.6 * inch
+    c.setFont("Helvetica", 11)
+    c.drawString(inch, y, f"Invoice #: {number}"); y -= 16
+    c.drawString(inch, y, f"Issue date: {issue.isoformat()}"); y -= 16
+    c.drawString(inch, y, f"Due date:   {due.isoformat()}"); y -= 16
+    c.drawString(inch, y, f"Currency:   {currency}"); y -= 28
+
+    c.setFont("Helvetica-Bold", 12); c.drawString(inch, y, f"From: {vendor}"); y -= 16
+    c.setFont("Helvetica", 10); c.drawString(inch, y, fake.address().replace("\n", ", ")); y -= 28
+    c.setFont("Helvetica-Bold", 12); c.drawString(inch, y, f"Bill to: {fake.company()}"); y -= 28
+
+    c.setFont("Helvetica-Bold", 10)
+    c.drawString(inch, y, "Description")
+    c.drawString(4.5 * inch, y, "Qty")
+    c.drawString(5.2 * inch, y, "Unit price")
+    c.drawString(6.5 * inch, y, "Amount")
+    y -= 14; c.line(inch, y, W - inch, y); y -= 14
+
+    c.setFont("Helvetica", 10)
+    subtotal = 0.0
+    for _ in range(random.randint(2, 5)):
+        qty = random.randint(1, 10)
+        unit = round(random.uniform(12, 450), 2)
+        amt = qty * unit
+        subtotal += amt
+        c.drawString(inch, y, fake.bs().title()[:40])
+        c.drawString(4.5 * inch, y, str(qty))
+        c.drawString(5.2 * inch, y, f"{symbol}{unit:,.2f}")
+        c.drawString(6.5 * inch, y, f"{symbol}{amt:,.2f}")
+        y -= 14
+
+    tax = round(subtotal * 0.1, 2); total = round(subtotal + tax, 2)
+    y -= 18
+    c.drawString(5 * inch, y, f"Subtotal: {symbol}{subtotal:,.2f}"); y -= 14
+    c.drawString(5 * inch, y, f"Tax (10%): {symbol}{tax:,.2f}"); y -= 14
+    c.setFont("Helvetica-Bold", 12); c.drawString(5 * inch, y, f"TOTAL: {symbol}{total:,.2f}")
+
+    c.save()
+    truth = {
+        "invoice_number": number,
+        "issue_date": issue.isoformat(),
+        "due_date": due.isoformat(),
+        "vendor_name": vendor,
+        "total_amount": total,
+        "currency": currency,
+    }
+    print(f"[invoice] {path.name}: {truth}")
+    return truth
+
+
+def make_email(path: Path) -> dict:
+    c = canvas.Canvas(str(path), pagesize=letter)
+    W, H = letter
+
+    sender = fake.company_email()
+    recipients = [fake.company_email() for _ in range(random.randint(1, 3))]
+    subject = fake.sentence(nb_words=6).rstrip(".")
+    sent = fake.date_time_between(start_date="-30d", end_date="now")
+    has_atts = random.random() < 0.4
+
+    y = H - inch
+    c.setFont("Helvetica-Bold", 12); c.drawString(inch, y, f"Subject: {subject}"); y -= 20
+    c.setFont("Helvetica", 10)
+    c.drawString(inch, y, f"From: {sender}"); y -= 14
+    c.drawString(inch, y, f"To:   {', '.join(recipients)}"); y -= 14
+    c.drawString(inch, y, f"Date: {sent.isoformat()}"); y -= 14
+    if has_atts:
+        c.drawString(inch, y, f"Attachments: {fake.word()}.pdf"); y -= 14
+    y -= 10; c.line(inch, y, W - inch, y); y -= 20
+
+    c.setFont("Helvetica", 10)
+    for para in (fake.paragraph(nb_sentences=3) for _ in range(3)):
+        line = ""
+        for w in para.split():
+            if len(line) + len(w) > 90:
+                c.drawString(inch, y, line); y -= 12
+                line = w
+            else:
+                line = (line + " " + w).strip()
+        if line:
+            c.drawString(inch, y, line); y -= 12
+        y -= 8
+
+    c.setFont("Helvetica-Oblique", 9)
+    c.drawString(inch, inch, "-- Best regards,")
+    c.drawString(inch, inch - 12, fake.name())
+
+    c.save()
+    truth = {
+        "sender": sender,
+        "recipients": recipients,
+        "subject": subject,
+        "sent_at": sent.isoformat(),
+        "has_attachments": has_atts,
+    }
+    print(f"[email]   {path.name}: {truth}")
+    return truth
+
+
+if __name__ == "__main__":
+    make_invoice(OUT / "invoice.pdf")
+    make_email(OUT / "email.pdf")
+    print(f"\nwrote to {OUT}")

--- a/config/claude/skills/anyformat-workflow/reference/nodes.md
+++ b/config/claude/skills/anyformat-workflow/reference/nodes.md
@@ -1,0 +1,99 @@
+# Node types reference
+
+10 node types. Each node's `type` in the `nodes` payload matches the DOT `class=` attribute for that node in the `graph` string.
+
+## Summary table
+
+| `type` | Purpose | Required `config` | Routing |
+|---|---|---|---|
+| `parse` | PDFs / spreadsheets / text → markdown (OCR, page rotation, figure enhancement, visual grounding). | `{}` (all optional: `engine`, `prompt_hint`, `page_rotation`, `figure_enhancement_enabled`, `visual_grounding_enabled`, `settings`) | linear |
+| `extract` | Markdown + schema → structured JSON via LLM. Can auto-synthesize a `smart_lookup` successor. | `{}` (optional: `use_images`, `smart_table_enabled`, `lookup_enabled`, `lookup_schema`, `lookup_suggestion`, `lookup_files`, `settings`). Schema supplied via `fields[]`. | linear |
+| `smart_table` | Multi-pass agentic table extraction w/ block-ID + bbox enrichment. Schema comes from `fields[]`. | `{}` (optional `settings`) | linear |
+| `smart_lookup` | Post-extraction enrichment — matches values against master CSV/catalog files. | `master_file_uris: [s3_uri, ...]` (required), optional `suggestion`, `settings`. Schema via `fields[]`. | linear |
+| `document_splitter` | LLM-routes one doc to multiple downstream extract nodes by category. | `rules: [{ id, name, description, partition_key? }, ...]` | **port-labeled** — each out-edge needs `source_port` matching a rule `name` |
+| `classify` | LLM-classifies doc into categories; routes downstream by label. | `user_prompt: str`, `categories: [{ id, name, description }, ...]` | **port-labeled** — each out-edge needs `source_port` matching a category `name` |
+| `filter` | Binary LLM gate — discards or forwards docs based on criteria. | `criteria: str`, optional `settings` | conditional (true → forward, false → end) |
+| `master_file` | Extraction guided by a reference/template file. | `master_file_uri: s3_uri` (required). Schema via `fields[]`. Optional `settings`. | linear |
+| `table_parse` | PDF → HTML tables (structural parsing, no LLM). | `{}` (none required) | linear |
+| `validate` | Checks extraction results against rules; appends verdicts to state. | `rules: [{ id, description, severity?, source_fields? }, ...]`, optional `settings` | linear |
+
+## Schema-bearing nodes
+
+Only these node types accept `fields[]`:
+
+- `extract`
+- `smart_table`
+- `smart_lookup`
+- `master_file`
+- `parse` (limited — mostly for prompt hints)
+
+For other node types, `fields` must be empty or omitted. PUT config will reject fields on e.g. a `classify` or `filter` node.
+
+## Edge syntax
+
+### Linear
+
+```
+"parse_1" -> "extract_1"
+```
+
+### Port-labeled (required for `classify` and `document_splitter`)
+
+The string after the colon is the edge's `source_port` and must match a category/rule `name`.
+
+```
+"classify_1":"invoice" -> "extract_invoices"
+"classify_1":"receipt" -> "extract_receipts"
+```
+
+Inside a JSON string the inner double-quotes need escaping. In a shell heredoc:
+
+```bash
+GRAPH='digraph G {
+  "splitter_1":"invoices" -> "extract_1";
+  "splitter_1":"emails"   -> "extract_2";
+}'
+```
+
+When building JSON by hand, escape as `\"splitter_1\":\"invoices\" -> \"extract_1\"`.
+
+## Splitter / classify example
+
+```json
+{
+  "node_id": "splitter_1",
+  "type": "document_splitter",
+  "config": {
+    "rules": [
+      { "id": "r-inv", "name": "invoices", "description": "Invoice documents: has invoice number, line items, total, vendor." },
+      { "id": "r-eml", "name": "emails",   "description": "Email correspondence: has from/to, subject, date, body." }
+    ]
+  }
+}
+```
+
+The `name` on each rule/category is the port label. Your DOT edges must match exactly (case-sensitive).
+
+## Implicit node synthesis
+
+- `extract` with `smart_table_enabled: true` → rewritten to `smart_table` at runtime.
+- `extract` with `lookup_enabled: true` + `lookup_files` + `lookup_schema` → auto-synthesizes a `smart_lookup` successor.
+
+You don't need to write these into the graph yourself — the core resolves them.
+
+## Source anchors
+
+Node classes live in `anyformat/services/anyformat-core/anyformat_core/graph/nodes/`:
+
+- `parse_node.py` — `ParseNode`
+- `extraction_node.py` — `ExtractionNode`
+- `smart_table_node.py` — `SmartTableNode`
+- `smart_lookup_node.py` — `SmartLookupNode`
+- `document_splitter_node.py` — `DocumentSplitterNode`
+- `classify_node.py` — `ClassifyNode`
+- `filter_node.py` — `FilterNode`
+- `master_file_extraction_node.py` — `MasterFileExtractionNode`
+- `table_parsing_node.py` — `TableParsingNode`
+- `validate_node.py` — `ValidateNode`
+
+DOT → node-type dispatch: `anyformat/services/anyformat-core/anyformat_core/graph/dot_graph.py:194`.

--- a/config/claude/skills/anyformat-workflow/reference/schemas.md
+++ b/config/claude/skills/anyformat-workflow/reference/schemas.md
@@ -1,0 +1,126 @@
+# Extraction schema reference
+
+A "schema" in anyformat is a list of **fields** attached to one or more extract-capable nodes within a WorkflowVersion. There is no standalone schema resource.
+
+## Field shape
+
+```json
+{
+  "name": "invoice_number",
+  "description": "Invoice ID as printed on the document",
+  "data_type": "string",
+  "source": "extraction",
+  "is_list": false,
+  "display_order": 10000,
+
+  "enum_options": null,
+  "nested_fields": null,
+  "custom_id": null,
+  "graph_node_id": null
+}
+```
+
+### Required per field
+
+- `name` — human-readable; the backend also derives a `sanitized_name` for uniqueness.
+- `description` — fed to the LLM prompt. Treat this as an instruction to the model. Quality of extraction correlates strongly with description quality.
+- `data_type` — one of the values below.
+
+### Optional
+
+- `source` — `"extraction"` (default) or `"smart_lookup"`. The latter marks fields that are populated by a `smart_lookup` successor, not the extract LLM.
+- `is_list` — set `true` when the value is naturally repeated (e.g., `recipients` on an email). Implied for `multi_select`.
+- `display_order` — integer; smaller renders first. Leave wide gaps (10000, 20000, …) so intermediate insertions don't need renumbering.
+- `enum_options` — required when `data_type` ∈ `enum`, `multi_select`. Each: `{ "name": "...", "description": "..." }`.
+- `nested_fields` — required when `data_type == "object"`. Each entry is another field (but **cannot itself be `object`** — nesting is one level deep).
+- `custom_id` — opaque string for integration with external systems.
+- `graph_node_id` — UUID of the target GraphNode. Only needed when attaching fields via a call that doesn't already know which node is being targeted.
+
+## Data types
+
+| `data_type` | Typical value | Notes |
+|---|---|---|
+| `string` | `"INV-001"` | Default for free text. |
+| `date` | `"2026-04-21"` | ISO 8601 date. |
+| `datetime` | `"2026-04-21T14:30:00Z"` | ISO 8601 with time. |
+| `float` | `1234.56` | Use for monetary amounts too. |
+| `integer` | `42` | |
+| `boolean` | `true` | |
+| `enum` | `"draft"` | Single value from `enum_options`. |
+| `multi_select` | `["draft","archived"]` | Multiple values from `enum_options`; implies `is_list`. |
+| `object` | `{...}` | Structured nested group; requires `nested_fields`. |
+
+## Per-node scoping
+
+A field belongs to exactly one **graph node**. How you express that depends on which endpoint you use:
+
+### Via POST `/workflows/` (one-shot)
+
+`fields[]` is a **flat top-level array**. All fields bind to `extract_1` by name, unless you supply either:
+
+- top-level `graph_node_id: <uuid>` applied to the whole batch, OR
+- per-field `graph_node_id: <uuid>`.
+
+Since UUIDs aren't known before creation, this is only practical when there's one extract node called `extract_1`. **Don't use for multi-extract workflows.**
+
+### Via PUT `/workflow-versions/{id}/config/` (atomic)
+
+`nodes` is a **dict keyed by node_id**, with each node's `fields` nested under it:
+
+```json
+{
+  "nodes": {
+    "extract_1": { "type": "extract", "config": {...}, "fields": [ {...}, {...} ] },
+    "extract_2": { "type": "extract", "config": {...}, "fields": [ {...}, {...} ] }
+  }
+}
+```
+
+This is the right choice for anything non-trivial — splitter/classify workflows, schema edits, multi-extract routing.
+
+## Fields vs manual_fields
+
+- `fields` — extracted from the document by the LLM/lookup/master_file nodes. Scoped per-node.
+- `manual_fields` — collection-level metadata entered by humans (e.g., "client name" set at upload time). Never populated from the document. Live on the WorkflowVersion, not on any graph node. Written via the `manual_field_values` map on `POST /files/upload/`.
+
+## Nesting example
+
+```json
+{
+  "name": "line_items",
+  "description": "Individual invoice line items",
+  "data_type": "object",
+  "is_list": true,
+  "display_order": 50000,
+  "nested_fields": [
+    { "name": "sku",         "description": "Product code",               "data_type": "string",  "display_order": 10000 },
+    { "name": "description", "description": "Line description",           "data_type": "string",  "display_order": 20000 },
+    { "name": "quantity",    "description": "Units purchased",            "data_type": "integer", "display_order": 30000 },
+    { "name": "unit_price",  "description": "Price per unit, pre-tax",    "data_type": "float",   "display_order": 40000 }
+  ]
+}
+```
+
+## Enum example
+
+```json
+{
+  "name": "payment_method",
+  "description": "How the invoice was paid",
+  "data_type": "enum",
+  "display_order": 60000,
+  "enum_options": [
+    { "name": "card",     "description": "Paid by credit/debit card" },
+    { "name": "transfer", "description": "Paid by bank transfer" },
+    { "name": "cash",     "description": "Paid in cash" }
+  ]
+}
+```
+
+## Gotchas
+
+- `enum` and `multi_select` **require** non-empty `enum_options` or validation will 400.
+- Non-enum `data_type`s **cannot** have `enum_options`; sending `[]` is OK (coerced to `null`), sending actual options 400s.
+- `nested_fields` are only valid on `object`. For any other type, omit them.
+- Field **names are unique per node after sanitization** (lowercased, punctuation stripped). `Invoice Number` and `invoice_number` collide.
+- Manual fields cannot have `data_type == "object"` (no nesting at the collection level).

--- a/config/claude/skills/anyformat-workflow/scripts/make_mixed.py
+++ b/config/claude/skills/anyformat-workflow/scripts/make_mixed.py
@@ -1,0 +1,259 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["reportlab", "faker"]
+# ///
+"""Generate a 3-page mixed PDF hitting invoice / packages / flights splitter categories.
+
+Run: uv run ~/.claude/skills/anyformat-workflow/scripts/make_mixed.py [out_dir]
+     (out_dir defaults to /tmp/anyformat-demo)
+
+Produces:
+  - mixed.pdf  — page 1 invoice, page 2 package label, page 3 boarding pass
+
+One page per branch means the document_splitter routes exactly one page
+to each downstream extract node, producing real extracted values in all
+three child extraction tabs.
+"""
+
+import random
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from faker import Faker
+from reportlab.lib.pagesizes import letter
+from reportlab.lib.units import inch
+from reportlab.pdfgen import canvas
+
+fake = Faker()
+OUT = Path(sys.argv[1] if len(sys.argv) > 1 else "/tmp/anyformat-demo")
+OUT.mkdir(parents=True, exist_ok=True)
+
+# Fixed vendor list so a companion CSV (vendor_catalog.csv) can demonstrate
+# smart_lookup joins. `draw_invoice` picks one at random and prints its name;
+# any CSV whose `vendor_name` column includes these will join cleanly.
+VENDORS = [
+    ("V-0001", "Acme Industries"),
+    ("V-0002", "Globex Corporation"),
+    ("V-0003", "Initech LLC"),
+    ("V-0004", "Umbrella Logistics"),
+    ("V-0005", "Stark Enterprises"),
+    ("V-0006", "Wayne Freight Co"),
+    ("V-0007", "Oceanic Traders"),
+    ("V-0008", "Hooli Supplies"),
+]
+
+
+def draw_invoice(c: canvas.Canvas) -> dict:
+    W, H = letter
+    issue = fake.date_between(start_date="-90d", end_date="today")
+    due = issue + timedelta(days=random.choice([14, 30, 45, 60]))
+    currency = random.choice(["USD", "EUR", "GBP"])
+    symbol = {"USD": "$", "EUR": "€", "GBP": "£"}[currency]
+    vendor = random.choice(VENDORS)[1]
+    number = f"INV-{fake.year()}-{random.randint(1000, 9999)}"
+
+    c.setFont("Helvetica-Bold", 22); c.drawString(inch, H - inch, "INVOICE")
+    y = H - 1.6 * inch
+    c.setFont("Helvetica", 11)
+    c.drawString(inch, y, f"Invoice #: {number}"); y -= 16
+    c.drawString(inch, y, f"Issue date: {issue.isoformat()}"); y -= 16
+    c.drawString(inch, y, f"Due date:   {due.isoformat()}"); y -= 16
+    c.drawString(inch, y, f"Currency:   {currency}"); y -= 28
+
+    c.setFont("Helvetica-Bold", 12); c.drawString(inch, y, f"From: {vendor}"); y -= 16
+    c.setFont("Helvetica", 10); c.drawString(inch, y, fake.address().replace("\n", ", ")); y -= 28
+    c.setFont("Helvetica-Bold", 12); c.drawString(inch, y, f"Bill to: {fake.company()}"); y -= 28
+
+    c.setFont("Helvetica-Bold", 10)
+    c.drawString(inch, y, "Description")
+    c.drawString(4.5 * inch, y, "Qty")
+    c.drawString(5.2 * inch, y, "Unit price")
+    c.drawString(6.5 * inch, y, "Amount")
+    y -= 14; c.line(inch, y, W - inch, y); y -= 14
+
+    c.setFont("Helvetica", 10)
+    subtotal = 0.0
+    for _ in range(random.randint(2, 5)):
+        qty = random.randint(1, 10)
+        unit = round(random.uniform(12, 450), 2)
+        amt = qty * unit
+        subtotal += amt
+        c.drawString(inch, y, fake.bs().title()[:40])
+        c.drawString(4.5 * inch, y, str(qty))
+        c.drawString(5.2 * inch, y, f"{symbol}{unit:,.2f}")
+        c.drawString(6.5 * inch, y, f"{symbol}{amt:,.2f}")
+        y -= 14
+
+    tax = round(subtotal * 0.1, 2); total = round(subtotal + tax, 2)
+    y -= 18
+    c.drawString(5 * inch, y, f"Subtotal: {symbol}{subtotal:,.2f}"); y -= 14
+    c.drawString(5 * inch, y, f"Tax (10%): {symbol}{tax:,.2f}"); y -= 14
+    c.setFont("Helvetica-Bold", 12); c.drawString(5 * inch, y, f"TOTAL: {symbol}{total:,.2f}")
+
+    return {
+        "invoice_number": number,
+        "issue_date": issue.isoformat(),
+        "vendor_name": vendor,
+        "total_amount": total,
+        "currency": currency,
+    }
+
+
+def draw_package_label(c: canvas.Canvas) -> dict:
+    W, H = letter
+    tracking = "".join(random.choices("ABCDEFGHJKLMNPQRSTUVWXYZ0123456789", k=12))
+    carrier = random.choice(["UPS", "FedEx", "DHL", "USPS"])
+    sender_name = fake.name()
+    sender_addr = fake.address().replace("\n", ", ")
+    recipient_name = fake.name()
+    recipient_addr = fake.address().replace("\n", ", ")
+    weight_kg = round(random.uniform(0.3, 25.0), 2)
+    ship_date = fake.date_between(start_date="-14d", end_date="today")
+    service = random.choice(["Ground", "Express", "Priority Overnight", "2-Day Air"])
+
+    c.setFont("Helvetica-Bold", 26); c.drawString(inch, H - inch, "SHIPPING LABEL")
+    c.setFont("Helvetica-Bold", 14); c.drawString(inch, H - 1.35 * inch, f"Carrier: {carrier}")
+
+    y = H - 2 * inch
+    c.setFont("Helvetica-Bold", 13); c.drawString(inch, y, "TRACKING NUMBER"); y -= 18
+    c.setFont("Courier-Bold", 20); c.drawString(inch, y, tracking); y -= 30
+
+    c.setFont("Helvetica-Bold", 11); c.drawString(inch, y, "FROM (Sender):"); y -= 14
+    c.setFont("Helvetica", 10)
+    c.drawString(inch, y, sender_name); y -= 12
+    c.drawString(inch, y, sender_addr); y -= 22
+
+    c.setFont("Helvetica-Bold", 11); c.drawString(inch, y, "TO (Recipient):"); y -= 14
+    c.setFont("Helvetica", 10)
+    c.drawString(inch, y, recipient_name); y -= 12
+    c.drawString(inch, y, recipient_addr); y -= 22
+
+    c.setFont("Helvetica", 10)
+    c.drawString(inch, y, f"Weight: {weight_kg} kg"); y -= 14
+    c.drawString(inch, y, f"Service: {service}"); y -= 14
+    c.drawString(inch, y, f"Ship date: {ship_date.isoformat()}"); y -= 14
+
+    c.setFont("Courier", 8)
+    c.drawString(inch, 1.2 * inch, "|" * 80)
+    c.drawString(inch, 1.0 * inch, "| | |   ||  ||| | ||   || |   |||  |  ||||  | || | |   ||")
+    c.setFont("Helvetica", 8); c.drawString(inch, 0.8 * inch, tracking)
+
+    return {
+        "tracking_number": tracking,
+        "carrier": carrier,
+        "sender_name": sender_name,
+        "recipient_name": recipient_name,
+        "weight_kg": weight_kg,
+        "ship_date": ship_date.isoformat(),
+    }
+
+
+def draw_boarding_pass(c: canvas.Canvas) -> dict:
+    W, H = letter
+    airlines = [("American Airlines", "AA"), ("Lufthansa", "LH"), ("United", "UA"), ("Iberia", "IB"), ("British Airways", "BA")]
+    airline_name, airline_code = random.choice(airlines)
+    flight_number = f"{airline_code}{random.randint(100, 9999)}"
+    passenger = fake.name().upper()
+    airports = [("JFK", "New York"), ("LHR", "London"), ("MAD", "Madrid"), ("FRA", "Frankfurt"),
+                ("CDG", "Paris"), ("LAX", "Los Angeles"), ("NRT", "Tokyo"), ("SFO", "San Francisco")]
+    origin, destination = random.sample(airports, 2)
+    departure = datetime.now() + timedelta(days=random.randint(1, 30), hours=random.randint(0, 23))
+    seat = f"{random.randint(1, 45)}{random.choice('ABCDEF')}"
+    gate = f"{random.choice('ABCDE')}{random.randint(1, 40)}"
+    boarding = departure - timedelta(minutes=30)
+    pnr = "".join(random.choices("ABCDEFGHJKLMNPQRSTUVWXYZ23456789", k=6))
+
+    c.setFont("Helvetica-Bold", 28); c.drawString(inch, H - inch, "BOARDING PASS")
+    c.setFont("Helvetica-Bold", 16); c.drawString(inch, H - 1.4 * inch, airline_name)
+
+    y = H - 2.2 * inch
+    c.setFont("Helvetica", 10); c.drawString(inch, y, "PASSENGER NAME"); y -= 14
+    c.setFont("Helvetica-Bold", 16); c.drawString(inch, y, passenger); y -= 30
+
+    c.setFont("Helvetica", 10); c.drawString(inch, y, "FLIGHT"); c.drawString(3.5 * inch, y, "DATE"); c.drawString(5.5 * inch, y, "SEAT"); y -= 14
+    c.setFont("Helvetica-Bold", 18)
+    c.drawString(inch, y, flight_number)
+    c.drawString(3.5 * inch, y, departure.strftime("%d %b %Y"))
+    c.drawString(5.5 * inch, y, seat)
+    y -= 36
+
+    c.setFont("Helvetica", 10); c.drawString(inch, y, "FROM"); c.drawString(4 * inch, y, "TO"); y -= 16
+    c.setFont("Helvetica-Bold", 22)
+    c.drawString(inch, y, origin[0]); c.drawString(4 * inch, y, destination[0]); y -= 16
+    c.setFont("Helvetica", 11)
+    c.drawString(inch, y, origin[1]); c.drawString(4 * inch, y, destination[1]); y -= 30
+
+    c.setFont("Helvetica", 10); c.drawString(inch, y, "DEPARTURE"); c.drawString(3 * inch, y, "BOARDING"); c.drawString(5 * inch, y, "GATE"); y -= 14
+    c.setFont("Helvetica-Bold", 14)
+    c.drawString(inch, y, departure.strftime("%H:%M"))
+    c.drawString(3 * inch, y, boarding.strftime("%H:%M"))
+    c.drawString(5 * inch, y, gate); y -= 30
+
+    c.setFont("Helvetica", 10); c.drawString(inch, y, f"Booking reference: {pnr}"); y -= 14
+    c.drawString(inch, y, f"Class: {random.choice(['Economy', 'Premium Economy', 'Business'])}"); y -= 14
+
+    c.setFont("Courier", 8)
+    c.drawString(inch, 1.2 * inch, "||| | || |||  | |||| ||  | || ||| | |  ||| || | |||  | | |||")
+
+    return {
+        "flight_number": flight_number,
+        "airline": airline_name,
+        "passenger_name": passenger,
+        "origin": origin[0],
+        "destination": destination[0],
+        "departure_time": departure.isoformat(timespec="minutes"),
+        "seat": seat,
+    }
+
+
+def make_mixed(path: Path) -> dict:
+    c = canvas.Canvas(str(path), pagesize=letter)
+    invoice = draw_invoice(c); c.showPage()
+    package = draw_package_label(c); c.showPage()
+    flight = draw_boarding_pass(c); c.showPage()
+    c.save()
+
+    truth = {"invoice": invoice, "packages": package, "flights": flight}
+    print(f"[mixed] {path.name}:")
+    for cat, fields in truth.items():
+        print(f"  {cat}: {fields}")
+    return truth
+
+
+def make_vendor_catalog(path: Path) -> None:
+    """CSV companion for smart_lookup demos on the invoice branch."""
+    lines = ["vendor_id,vendor_name,contact_email,payment_terms"]
+    for vid, vname in VENDORS:
+        slug = vname.lower().replace(" ", "").replace(",", "")
+        terms = random.choice(["Net 15", "Net 30", "Net 45", "Net 60"])
+        lines.append(f"{vid},{vname},ap@{slug}.example,{terms}")
+    path.write_text("\n".join(lines) + "\n")
+    print(f"[catalog] {path.name}: {len(VENDORS)} vendors")
+
+
+def make_airline_codes(path: Path) -> None:
+    """CSV companion for master_file demos on the flights branch.
+
+    Covers every airline that `draw_boarding_pass` may emit, so the
+    reference-guided extraction always has a matching row to anchor on.
+    """
+    rows = [
+        ("AA", "American Airlines", "USA"),
+        ("LH", "Lufthansa", "Germany"),
+        ("UA", "United", "USA"),
+        ("IB", "Iberia", "Spain"),
+        ("BA", "British Airways", "UK"),
+    ]
+    lines = ["airline_code,airline_name,country"]
+    for code, name, country in rows:
+        lines.append(f"{code},{name},{country}")
+    path.write_text("\n".join(lines) + "\n")
+    print(f"[airlines] {path.name}: {len(rows)} airlines")
+
+
+if __name__ == "__main__":
+    make_mixed(OUT / "mixed.pdf")
+    make_vendor_catalog(OUT / "vendor_catalog.csv")
+    make_airline_codes(OUT / "airline_codes.csv")
+    print(f"\nwrote to {OUT}")


### PR DESCRIPTION
## Summary

New Claude skill for creating anyformat workflows end-to-end against the local backend — auth, graph + schema construction for all 10 node types, PDF upload, run, and result fetching.

- `SKILL.md` with the decision guide, quickstart, and references
- `reference/` — per-topic docs (auth, api, nodes, schemas, examples) with working curl payloads for linear, splitter, classify, and smart_lookup patterns
- `reference/fixtures/make_fixtures.py` — PEP 723 script generating invoice / email PDFs
- `scripts/make_mixed.py` — PEP 723 script generating a 3-page mixed PDF plus companion `vendor_catalog.csv` and `airline_codes.csv` for splitter / smart_lookup / master_file regression demos

Dog-fooded against local backend while building the splits-identity-rebuild branch — covers real payloads that worked end-to-end.

## Test plan

- [ ] `/anyformat-workflow` triggers in Claude Code after sync
- [ ] Quickstart curl block creates a linear workflow against local `http://localhost:8080`
- [ ] Splitter example (`reference/examples.md#splitter`) creates a multi-extract workflow via POST + PUT config
- [ ] `uv run scripts/make_mixed.py` produces `mixed.pdf` + two CSVs in `/tmp/anyformat-demo`